### PR TITLE
fix(pricing): correct Opus rates to $15/$75 per million tokens

### DIFF
--- a/hooks/hydra-token-math.js
+++ b/hooks/hydra-token-math.js
@@ -14,7 +14,7 @@ const os = require('os');
 const PRICING = {
   'claude-haiku-4':  { input: 1, output: 5 },
   'claude-sonnet-4': { input: 3, output: 15 },
-  'claude-opus-4':   { input: 5, output: 25 }
+  'claude-opus-4':   { input: 15, output: 75 }
 };
 
 function getPrice(model) {


### PR DESCRIPTION
## Bug

`hooks/hydra-token-math.js` prices Opus incorrectly:

```js
const PRICING = {
  'claude-haiku-4':  { input: 1, output: 5 },   // correct (Haiku 4.5)
  'claude-sonnet-4': { input: 3, output: 15 },  // correct (Sonnet 4)
  'claude-opus-4':   { input: 5, output: 25 }   // wrong: Opus is $15 / $75
};
```

Anthropic prices Opus 4 at **$15 / MTok input, $75 / MTok output**. The haiku and sonnet entries already match their published rates; only opus is off, which points to a data-entry slip rather than an intentional model.

Everything flows through `tierCost`, so this understates:

- the "actual cost" for any Opus turns, and
- the all-Opus baseline (`asOpusCost`), and therefore the headline `savedUSD` / `savedPct` shown in the statusline and `/hydra:stats`,

by 3x. Quick check (2M input, 0.5M output, 5M cache read, 1M cache create on Opus):

```
all-Opus baseline at $5/$25:   $30.00
all-Opus baseline at $15/$75:  $90.00   (3x)
```

So the tool is currently underselling its own savings.

## Fix

```js
'claude-opus-4': { input: 15, output: 75 }
```

One line, matches Anthropic's published Opus pricing and the format of the other two tiers.

Unrelated aside, happy to leave for a separate PR: `tierCost` charges `cache_create` at 1x input, but Anthropic bills 5-minute cache writes at 1.25x base input. The cache-read `* 0.1` is already correct.
